### PR TITLE
fix: correction de la pluralisation du modèle Address

### DIFF
--- a/lettings/models.py
+++ b/lettings/models.py
@@ -16,6 +16,11 @@ class Address(models.Model):
         max_length=3, validators=[MinLengthValidator(3)]
     )
 
+    class Meta:
+        """Configuration supplémentaire du modèle Address."""
+
+        verbose_name_plural = "Addresses"
+
     def __str__(self):
         """Retourne une représentation lisible de l'adresse (numéro + rue)."""
         return f"{self.number} {self.street}"


### PR DESCRIPTION
## Résumé

Correction de la pluralisation incorrecte du modèle `Address` dans l'interface d'administration Django.

Closes #5

## Problème

Django génère automatiquement le nom pluriel d'un modèle en ajoutant un simple `s`. Pour `Address`, cela produisait `Addresss` (trois `s`) dans l'admin.

## Solution

Ajout d'une classe `Meta` avec `verbose_name_plural = "Addresses"` dans le modèle `Address` de `lettings/models.py`, forçant Django à utiliser la forme plurielle correcte.

```python
class Meta:
    verbose_name_plural = "Addresses"
```

## Fichiers modifiés

- `lettings/models.py` — ajout de la classe `Meta` sur le modèle `Address`