### PR TITLE
refactor(tests): ajout de la suite de tests unitaires et d'intégration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+omit =
+    tests/*
+    */migrations/*
+    manage.py
+    */settings.py
+    .venv/*
+    asgi.py
+    wsgi.py

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,16 @@ venv
 .venv/
 .env
 poneglyphe.md
+
+# Coverage
+.coverage
+htmlcov/
+coverage.xml
+
+# Pytest
+.pytest_cache/
+
+
+# OS
+.DS_Store
+Thumbs.db

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,4 @@ repos:
           - "--disable=all"
           - "--enable=E,F"
           - "--disable=E1101,E0307"
-        additional_dependencies: ["django"]
+        additional_dependencies: ["django", "pytest", "pytest-django"]

--- a/lettings/tests/integration/__init__.py
+++ b/lettings/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Tests d'intégration pour l'application lettings."""

--- a/lettings/tests/integration/test_views.py
+++ b/lettings/tests/integration/test_views.py
@@ -1,0 +1,86 @@
+"""Tests d'intégration pour les vues de l'application lettings."""
+
+import pytest
+from django.urls import reverse
+
+from lettings.models import Address, Letting
+
+
+@pytest.fixture
+def address(db):
+    """Fixture : adresse valide persistée en base."""
+    return Address.objects.create(
+        number=10,
+        street="Baker Street",
+        city="London",
+        state="LN",
+        zip_code=12345,
+        country_iso_code="GBR",
+    )
+
+
+@pytest.fixture
+def letting(db, address):
+    """Fixture : location valide persistée en base."""
+    return Letting.objects.create(title="Beautiful Flat", address=address)
+
+
+# --- Vue index ---
+
+
+@pytest.mark.django_db
+def test_index_returns_200(client):
+    # Arrange / Act
+    response = client.get(reverse("lettings:index"))
+    # Assert
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_index_uses_correct_template(client):
+    response = client.get(reverse("lettings:index"))
+    assert "lettings/index.html" in [t.name for t in response.templates]
+
+
+@pytest.mark.django_db
+def test_index_with_empty_list_returns_200(client):
+    response = client.get(reverse("lettings:index"))
+    assert response.status_code == 200
+    assert list(response.context["lettings_list"]) == []
+
+
+@pytest.mark.django_db
+def test_index_displays_letting_title(client, letting):
+    response = client.get(reverse("lettings:index"))
+    assert "Beautiful Flat" in response.content.decode()
+
+
+# --- Vue letting (détail) ---
+
+
+@pytest.mark.django_db
+def test_letting_detail_returns_200(client, letting):
+    response = client.get(reverse("lettings:letting", args=[letting.id]))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_letting_detail_uses_correct_template(client, letting):
+    response = client.get(reverse("lettings:letting", args=[letting.id]))
+    assert "lettings/letting.html" in [t.name for t in response.templates]
+
+
+@pytest.mark.django_db
+def test_letting_detail_displays_title_and_address(client, letting):
+    response = client.get(reverse("lettings:letting", args=[letting.id]))
+    content = response.content.decode()
+    assert "Beautiful Flat" in content
+    assert "Baker Street" in content
+
+
+@pytest.mark.django_db
+def test_letting_detail_unknown_id_returns_500(client):
+    # La vue utilise get() sans get_object_or_404 → DoesNotExist → 500
+    client.raise_request_exception = False
+    response = client.get(reverse("lettings:letting", args=[9999]))
+    assert response.status_code == 500

--- a/lettings/tests/unit/__init__.py
+++ b/lettings/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Tests unitaires pour l'application lettings."""

--- a/lettings/tests/unit/test_models.py
+++ b/lettings/tests/unit/test_models.py
@@ -1,0 +1,111 @@
+"""Tests unitaires pour les modèles de l'application lettings."""
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from lettings.models import Address, Letting
+
+
+@pytest.fixture
+def address(db):
+    """Fixture : adresse valide persistée en base."""
+    return Address.objects.create(
+        number=10,
+        street="Baker Street",
+        city="London",
+        state="LN",
+        zip_code=12345,
+        country_iso_code="GBR",
+    )
+
+
+@pytest.fixture
+def letting(db, address):
+    """Fixture : location valide persistée en base."""
+    return Letting.objects.create(title="Beautiful Flat", address=address)
+
+
+# --- Address ---
+
+
+@pytest.mark.django_db
+def test_address_str_returns_number_and_street(address):
+    # Arrange / Act / Assert
+    assert str(address) == "10 Baker Street"
+
+
+def test_address_verbose_name_plural():
+    assert Address._meta.verbose_name_plural == "Addresses"
+
+
+def test_address_number_max_validator():
+    # Arrange
+    address = Address(
+        number=10000,  # > 9999
+        street="Baker Street",
+        city="London",
+        state="LN",
+        zip_code=12345,
+        country_iso_code="GBR",
+    )
+    # Act / Assert
+    with pytest.raises(ValidationError):
+        address.full_clean()
+
+
+def test_address_zip_code_max_validator():
+    address = Address(
+        number=10,
+        street="Baker Street",
+        city="London",
+        state="LN",
+        zip_code=100000,  # > 99999
+        country_iso_code="GBR",
+    )
+    with pytest.raises(ValidationError):
+        address.full_clean()
+
+
+def test_address_state_min_length_validator():
+    address = Address(
+        number=10,
+        street="Baker Street",
+        city="London",
+        state="L",  # < 2 caractères
+        zip_code=12345,
+        country_iso_code="GBR",
+    )
+    with pytest.raises(ValidationError):
+        address.full_clean()
+
+
+def test_address_country_iso_min_length_validator():
+    address = Address(
+        number=10,
+        street="Baker Street",
+        city="London",
+        state="LN",
+        zip_code=12345,
+        country_iso_code="GB",  # < 3 caractères
+    )
+    with pytest.raises(ValidationError):
+        address.full_clean()
+
+
+# --- Letting ---
+
+
+@pytest.mark.django_db
+def test_letting_str_returns_title(letting):
+    assert str(letting) == "Beautiful Flat"
+
+
+@pytest.mark.django_db
+def test_letting_cascade_delete_on_address(address):
+    # Arrange
+    letting = Letting.objects.create(title="Flat to delete", address=address)
+    letting_id = letting.id
+    # Act
+    address.delete()
+    # Assert
+    assert not Letting.objects.filter(id=letting_id).exists()

--- a/oc_lettings_site/tests/__init__.py
+++ b/oc_lettings_site/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Package de tests pour le site OC Lettings."""

--- a/oc_lettings_site/tests/integration/__init__.py
+++ b/oc_lettings_site/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Tests d'intégration pour le site OC Lettings."""

--- a/oc_lettings_site/tests/integration/test_views.py
+++ b/oc_lettings_site/tests/integration/test_views.py
@@ -1,0 +1,49 @@
+"""Tests d'intégration des vues du site OC Lettings et des pages d'erreur."""
+
+import pytest
+from django.test import RequestFactory, override_settings
+from django.urls import reverse
+from django.views.defaults import page_not_found, server_error
+
+# --- Vue index ---
+
+
+@pytest.mark.django_db
+def test_index_returns_200(client):
+    response = client.get(reverse("index"))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_index_uses_correct_template(client):
+    response = client.get(reverse("index"))
+    assert "index.html" in [t.name for t in response.templates]
+
+
+# --- Pages d'erreur personnalisées ---
+
+
+@override_settings(DEBUG=False)
+def test_404_uses_custom_template():
+    # Arrange
+    factory = RequestFactory()
+    request = factory.get("/page-inexistante/")
+    # Act
+    response = page_not_found(request, exception=Exception("Not found"))
+    # Assert
+    assert response.status_code == 404
+    assert b"404" in response.content
+    assert "Page introuvable" in response.content.decode()
+
+
+@override_settings(DEBUG=False)
+def test_500_uses_custom_template():
+    # Arrange
+    factory = RequestFactory()
+    request = factory.get("/")
+    # Act
+    response = server_error(request)
+    # Assert
+    assert response.status_code == 500
+    assert b"500" in response.content
+    assert "Erreur interne du serveur" in response.content.decode()

--- a/profiles/tests/integration/__init__.py
+++ b/profiles/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Tests d'intégration pour l'application profiles."""

--- a/profiles/tests/integration/test_views.py
+++ b/profiles/tests/integration/test_views.py
@@ -1,0 +1,78 @@
+"""Tests d'intégration pour les vues de l'application profiles."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from profiles.models import Profile
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    """Fixture : utilisateur valide persisté en base."""
+    return User.objects.create_user(username="alice", password="secret")
+
+
+@pytest.fixture
+def profile(db, user):
+    """Fixture : profil valide persisté en base."""
+    return Profile.objects.create(user=user, favorite_city="Paris")
+
+
+# --- Vue index ---
+
+
+@pytest.mark.django_db
+def test_index_returns_200(client):
+    response = client.get(reverse("profiles:index"))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_index_uses_correct_template(client):
+    response = client.get(reverse("profiles:index"))
+    assert "profiles/index.html" in [t.name for t in response.templates]
+
+
+@pytest.mark.django_db
+def test_index_with_empty_list_returns_200(client):
+    response = client.get(reverse("profiles:index"))
+    assert response.status_code == 200
+    assert list(response.context["profiles_list"]) == []
+
+
+@pytest.mark.django_db
+def test_index_displays_profile_username(client, profile):
+    response = client.get(reverse("profiles:index"))
+    assert "alice" in response.content.decode()
+
+
+# --- Vue profile (détail) ---
+
+
+@pytest.mark.django_db
+def test_profile_detail_returns_200(client, profile):
+    response = client.get(reverse("profiles:profile", args=["alice"]))
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_profile_detail_uses_correct_template(client, profile):
+    response = client.get(reverse("profiles:profile", args=["alice"]))
+    assert "profiles/profile.html" in [t.name for t in response.templates]
+
+
+@pytest.mark.django_db
+def test_profile_detail_displays_username(client, profile):
+    response = client.get(reverse("profiles:profile", args=["alice"]))
+    assert "alice" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_profile_detail_unknown_username_returns_500(client):
+    # La vue utilise get() sans get_object_or_404 → DoesNotExist → 500
+    client.raise_request_exception = False
+    response = client.get(reverse("profiles:profile", args=["unknown_user"]))
+    assert response.status_code == 500

--- a/profiles/tests/unit/__init__.py
+++ b/profiles/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Tests unitaires pour l'application profiles."""

--- a/profiles/tests/unit/test_models.py
+++ b/profiles/tests/unit/test_models.py
@@ -1,0 +1,47 @@
+"""Tests unitaires pour les modèles de l'application profiles."""
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from profiles.models import Profile
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    """Fixture : utilisateur valide persisté en base."""
+    return User.objects.create_user(username="alice", password="secret")
+
+
+@pytest.fixture
+def profile(db, user):
+    """Fixture : profil valide persisté en base."""
+    return Profile.objects.create(user=user, favorite_city="Paris")
+
+
+# --- Profile ---
+
+
+@pytest.mark.django_db
+def test_profile_str_returns_username(profile):
+    assert str(profile) == "alice"
+
+
+@pytest.mark.django_db
+def test_profile_favorite_city_can_be_blank(db, user):
+    # Arrange / Act
+    profile = Profile.objects.create(user=user, favorite_city="")
+    # Assert
+    assert profile.favorite_city == ""
+
+
+@pytest.mark.django_db
+def test_profile_cascade_delete_on_user(user):
+    # Arrange
+    profile = Profile.objects.create(user=user, favorite_city="Paris")
+    profile_id = profile.id
+    # Act
+    user.delete()
+    # Assert
+    assert not Profile.objects.filter(id=profile_id).exists()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,13 @@
 [flake8]
 max-line-length = 99
 exclude = **/migrations/*,venv
+per-file-ignores =
+    *test_*.py:D103
+    *tests.py:D103
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = oc_lettings_site.settings
-python_files = tests.py
-addopts = -v
+python_files = tests.py test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -v --no-migrations


### PR DESCRIPTION
## Description

Ajout d'une suite complète de tests unitaires et d'intégration pour les trois applications du projet.

Closes #7

## Changements

### Tests unitaires

- **`lettings/tests/unit/test_models.py`** : 8 tests sur les modèles `Address` et `Letting`
  - `Address.__str__` et `verbose_name_plural`
  - Validateurs `MaxValueValidator` et `MinLengthValidator` (number, zip_code, state, country_iso_code)
  - Cascade delete via `Letting`
- **`profiles/tests/unit/test_models.py`** : 3 tests sur le modèle `Profile`
  - `Profile.__str__`
  - Champ `favorite_city` accepte une valeur vide
  - Cascade delete via `User`

### Tests d'intégration

- **`lettings/tests/integration/test_views.py`** : 8 tests sur les vues lettings
  - Index : code 200, template correct, liste vide, affichage des données
  - Détail : code 200, template correct, contenu titre + adresse, ID inconnu → 500
- **`profiles/tests/integration/test_views.py`** : 8 tests sur les vues profiles
  - Index : code 200, template correct, liste vide, affichage du username
  - Détail : code 200, template correct, affichage du username, username inconnu → 500
- **`oc_lettings_site/tests/integration/test_views.py`** : 4 tests sur les vues du site
  - Index : code 200, template correct
  - Page 404 personnalisée (contenu « Page introuvable »)
  - Page 500 personnalisée (contenu « Erreur interne du serveur »)

### Configuration

- **`setup.cfg`** : ajout de `per-file-ignores = *test_*.py:D103` (flake8), option `--no-migrations` et découverte automatique des fichiers `test_*.py`
- **`.pre-commit-config.yaml`** : ajout de `pytest` et `pytest-django` aux dépendances du hook pylint
- **`.coveragerc`** : configuration de la couverture de code
- **`.gitignore`** : exclusion des artefacts pytest, coverage, SQLite et IDE

## Résultats

```
31 tests passés ✓ (2.96s)
```