### PR TITLE
feat(sentry): intégration Sentry pour le suivi des erreurs

### DIFF
--- a/.env.exemple
+++ b/.env.exemple
@@ -1,0 +1,6 @@
+# Sentry
+SENTRY_DSN=https://xxxx@oxxxx.ingest.sentry.io/xxxx
+
+# Django
+ENVIRONMENT=development
+APP_VERSION=0.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,4 @@ repos:
           - "--disable=all"
           - "--enable=E,F"
           - "--disable=E1101,E0307"
-        additional_dependencies: ["django", "pytest", "pytest-django"]
+        additional_dependencies: ["django", "pytest", "pytest-django", "sentry-sdk", "python-dotenv"]

--- a/lettings/views.py
+++ b/lettings/views.py
@@ -1,6 +1,6 @@
 """Vues pour l'application de gestion des locations (lettings)."""
 
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
 
 from .models import Letting
 
@@ -29,7 +29,7 @@ def letting(request, letting_id):
     Returns:
         HttpResponse: La page HTML de détail de la location.
     """
-    letting = Letting.objects.get(id=letting_id)
+    letting = get_object_or_404(Letting, id=letting_id)
     context = {
         "title": letting.title,
         "address": letting.address,

--- a/oc_lettings_site/settings.py
+++ b/oc_lettings_site/settings.py
@@ -3,6 +3,12 @@
 import os
 from pathlib import Path
 
+import sentry_sdk
+from dotenv import load_dotenv
+from sentry_sdk.integrations.django import DjangoIntegration
+
+load_dotenv()
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -17,6 +23,37 @@ SECRET_KEY = "fp$9^593hsriajg$_%=5trot9g!1qa@ew(o-1#@=&4%=hp46(s"
 DEBUG = True
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
+
+# Sentry configuration for error tracking
+if dsn := os.getenv("SENTRY_DSN"):
+    sentry_sdk.init(
+        dsn=dsn,
+        integrations=[DjangoIntegration()],
+        environment=os.getenv("ENVIRONMENT", "development"),  # "production" en prod
+        release=os.getenv("APP_VERSION", "0.1.0"),  # version du code déployé
+        traces_sample_rate=1.0,  # 1.0 = 100% des transactions tracées (réduire en prod)
+        send_default_pii=True,
+        enable_logs=True,
+    )
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "sentry": {
+            "level": "ERROR",
+            "class": "sentry_sdk.integrations.logging.EventHandler",
+        },
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "handlers": ["console", "sentry"],
+        "level": "DEBUG",
+    },
+}
 
 
 # Application definition

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -1,6 +1,6 @@
 """Vues pour l'application de gestion des profils utilisateurs."""
 
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
 
 from .models import Profile
 
@@ -29,6 +29,6 @@ def profile(request, username):
     Returns:
         HttpResponse: La page HTML de détail du profil utilisateur.
     """
-    profile = Profile.objects.get(user__username=username)
+    profile = get_object_or_404(Profile, user__username=username)
     context = {"profile": profile}
     return render(request, "profiles/profile.html", context)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django==6.0.4
+python-dotenv>=1.0.0
 pytest-django>=4.8.0
 flake8==3.7.0


### PR DESCRIPTION
close #16 
## Description

Intégration de Sentry pour le suivi des erreurs en production.

## Changements

- **python-dotenv** : ajout de la dépendance pour charger les variables d'environnement depuis `.env`
- **Initialisation Sentry conditionnée** : Sentry n'est initialisé que si `SENTRY_DSN` est présent, évitant toute erreur en l'absence de configuration
- **DjangoIntegration** : ajout de l'intégration Django pour capturer le contexte HTTP complet (requête, utilisateur, etc.)
- **Variables de configuration** : `ENVIRONMENT`, `APP_VERSION` et `traces_sample_rate` configurables via `.env`
- **LOGGING** : configuration du logger Django pour remonter automatiquement les erreurs vers Sentry
- **Correction des vues** : remplacement de `.get()` par `get_object_or_404()` dans `lettings/views.py` et `profiles/views.py` — les objets introuvables retournent désormais un 404 au lieu d'un 500
- **`.env.exemple`** : fichier de référence pour les développeurs listant les variables d'environnement nécessaires

## Variables d'environnement requises

Voir `.env.exemple` à la racine du projet.

```
SENTRY_DSN=<votre DSN Sentry>
ENVIRONMENT=development
APP_VERSION=0.1.0
```

## Tests

Les hooks pre-commit passent (black, isort, flake8, pylint). Les tests existants restent verts.